### PR TITLE
Added debouncing of input readings, to prevent false double clicks

### DIFF
--- a/OneButton.h
+++ b/OneButton.h
@@ -9,6 +9,7 @@
 // 21.04.2011 transformed into a library
 // 01.12.2011 include file changed to work with the Arduino 1.0 environment
 // 23.03.2014 Enhanced long press functionalities by adding longPressStart and longPressStop callbacks
+// 06.04.2014 Added debouncing of input readings, to prevent false double clicks
 // -----
 
 #ifndef OneButton_h
@@ -51,6 +52,9 @@ public:
   void tick(void);
   bool isLongPressed();
 
+  // ----- public debounce functions ------
+  void setDebounceDelay(int delay);
+  
 private:
   int _pin;        // hardware pin number. 
   int _clickTicks; // number of ticks that have to pass by before a click is detected
@@ -73,6 +77,14 @@ private:
   // They are initialized once on program start and are updated every time the tick function is called.
   int _state;
   unsigned long _startTime; // will be set in state 1
+
+  // Debounce variables and functions
+  // Help prevent bouncing button states from being read as double clicks
+  int _db_buttonState;                // the current reading from the input pin
+  int _db_lastButtonState;            // the previous reading from the input pin
+  unsigned long _db_lastDebounceTime; // the last time the output pin was toggled
+  unsigned long _db_debounceDelay;    // the debounce time; increase if the output flickers
+  boolean debounce(boolean reading);  // method to debounce the digital reading, call every loop
 };
 
 #endif


### PR DESCRIPTION
Without debouncing the input reading, a single button push can read as several short button presses ("caused by a small ripple of current that forms when a mechanical switch is pushed in an electrical circuit and makes a series of short contacts"). OneButton treats such an event falsely as a double click. This commit adds a debouncing method to the class. The input reading has to stay the same (high or low) during a short timespan, before the button push is treated as an actual click. This timespan (debounce delay) defaults to 50ms, but can be set at setup/runtime. Different buttons or circuits may require different debounce delays to remove the "flickering" of the reading at first contact. 