### PR TITLE
Explicitly initialize all callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/OneButton.cpp
+++ b/OneButton.cpp
@@ -40,6 +40,12 @@ OneButton::OneButton(int pin, int activeLow)
     _buttonPressed = HIGH;
   } // if
 
+
+  _doubleClickFunc = NULL;
+  _pressFunc = NULL;
+  _longPressStartFunc = NULL;
+  _longPressStopFunc = NULL;
+  _duringLongPressFunc = NULL;
 } // OneButton
 
 


### PR DESCRIPTION
I was having an issue with this library under Teensy.  After many hours spent investigating, it was crashing in in OneButton.cpp:127, the following few lines:

``` c++
     if (_pressFunc) _pressFunc();
     if (_longPressStartFunc) _longPressStartFunc();
     if (_duringLongPressFunc) _duringLongPressFunc();
```

I did not have these callbacks set, but somehow they were not NULL/false ether, so they were being "called" and crashing the program.

After setting them to NULL explicitly the problem went away.

Thanks for writing such flexible button library for Arduino.  It rocks, and I use it on all of my projects now :)
