### PR TITLE
Initializing _clickFunc with NULL.

### DIFF
--- a/OneButton.cpp
+++ b/OneButton.cpp
@@ -35,7 +35,7 @@ OneButton::OneButton(int pin, int activeLow)
     _buttonPressed = HIGH;
   } // if
 
-
+  _clickFunc = NULL;
   _doubleClickFunc = NULL;
   _pressFunc = NULL;
   _longPressStartFunc = NULL;


### PR DESCRIPTION
_clickFunc was not initialized with NULL.
It stopped programs when a button is clicked while no callback has been
assigned to the OneButton instance.