### PR TITLE
Also take button bounce effect into account in state 3

### DIFF
--- a/src/OneButton.cpp
+++ b/src/OneButton.cpp
@@ -147,10 +147,13 @@ void OneButton::tick(void)
 
     } else if (buttonLevel == _buttonPressed) {
       _state = 3; // step to state 3
+      _startTime = now; // remember starting time
     } // if
 
   } else if (_state == 3) { // waiting for menu pin being released finally.
-    if (buttonLevel == _buttonReleased) {
+    // Stay here for at least _debounceTicks because else we might end up in state 1 if the
+    // button bounces for too long.
+    if (buttonLevel == _buttonReleased && ((unsigned long)(now - _startTime) > _debounceTicks)) {
       // this was a 2 click sequence.
       if (_doubleClickFunc) _doubleClickFunc();
       _state = 0; // restart.


### PR DESCRIPTION
The second click in a double click wasn't debounced. As a result, if the
button bounces a few times, the first bounce would get the state machine
from state 2 into state 3. A second bounce would then get the state
machine from state 3 into state 0. If then the button finally reaches a
stable ON state, the state machines transitions from state 0 to state 1.

If the button then remains stable for longer than the debounce time,
which is likely, the state machine will transition from 1 to 2 where
eventually a timeout can happen. This all in the second click of a
double click.

This isn't noticable if there is a certain delay between two consecutive
calls to the tick() function, but since I don't have any delays in my
loop() function, the tick() function gets called continously and I ran
into this problem quite often.

This patch makes sure that we stay for at least _debounceTicks in state
3 and by the time we leave state 3, the state of the button is
stabilized and the state machine doesn't transition to any unwanted
states anymore.