### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -15,7 +15,7 @@ callbackFunction	KEYWORD1
 
 setClickTicks	KEYWORD2
 setPressTicks	KEYWORD2
-setDebounceTicks KEYWORD2
+setDebounceTicks	KEYWORD2
 attachClick	KEYWORD2
 attachDoubleClick	KEYWORD2
 attachLongPressStart	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords