### PR TITLE
switched callbacFunction to std::function

### DIFF
--- a/src/OneButton.cpp
+++ b/src/OneButton.cpp
@@ -76,14 +76,14 @@ void OneButton::setPressTicks(int ticks)
 
 
 // save function for click event
-void OneButton::attachClick(callbackFunction newFunction)
+void OneButton::attachClick(const callbackFunction& newFunction)
 {
   _clickFunc = newFunction;
 } // attachClick
 
 
 // save function for doubleClick event
-void OneButton::attachDoubleClick(callbackFunction newFunction)
+void OneButton::attachDoubleClick(const callbackFunction& newFunction)
 {
   _doubleClickFunc = newFunction;
 } // attachDoubleClick
@@ -92,25 +92,25 @@ void OneButton::attachDoubleClick(callbackFunction newFunction)
 // save function for press event
 // DEPRECATED, is replaced by attachLongPressStart, attachLongPressStop,
 // attachDuringLongPress,
-void OneButton::attachPress(callbackFunction newFunction)
+void OneButton::attachPress(const callbackFunction& newFunction)
 {
   _pressFunc = newFunction;
 } // attachPress
 
 // save function for longPressStart event
-void OneButton::attachLongPressStart(callbackFunction newFunction)
+void OneButton::attachLongPressStart(const callbackFunction& newFunction)
 {
   _longPressStartFunc = newFunction;
 } // attachLongPressStart
 
 // save function for longPressStop event
-void OneButton::attachLongPressStop(callbackFunction newFunction)
+void OneButton::attachLongPressStop(const callbackFunction& newFunction)
 {
   _longPressStopFunc = newFunction;
 } // attachLongPressStop
 
 // save function for during longPress event
-void OneButton::attachDuringLongPress(callbackFunction newFunction)
+void OneButton::attachDuringLongPress(const callbackFunction& newFunction)
 {
   _duringLongPressFunc = newFunction;
 } // attachDuringLongPress

--- a/src/OneButton.h
+++ b/src/OneButton.h
@@ -24,12 +24,11 @@
 #define OneButton_h
 
 #include "Arduino.h"
+#include <functional>
 
 // ----- Callback function types -----
 
-extern "C" {
-typedef void (*callbackFunction)(void);
-}
+typedef std::function<void(void)> callbackFunction;
 
 
 class OneButton
@@ -53,14 +52,14 @@ public:
 
   // attach functions that will be called when button was pressed in the
   // specified way.
-  void attachClick(callbackFunction newFunction);
-  void attachDoubleClick(callbackFunction newFunction);
+  void attachClick(const callbackFunction& newFunction);
+  void attachDoubleClick(const callbackFunction& newFunction);
   void attachPress(
-      callbackFunction newFunction); // DEPRECATED, replaced by longPressStart,
+      const callbackFunction& newFunction); // DEPRECATED, replaced by longPressStart,
                                      // longPressStop and duringLongPress
-  void attachLongPressStart(callbackFunction newFunction);
-  void attachLongPressStop(callbackFunction newFunction);
-  void attachDuringLongPress(callbackFunction newFunction);
+  void attachLongPressStart(const callbackFunction& newFunction);
+  void attachLongPressStop(const callbackFunction& newFunction);
+  void attachDuringLongPress(const callbackFunction& newFunction);
 
   // ----- State machine functions -----
 


### PR DESCRIPTION
Switched to std:function to enable capturing variables (e.g. with lambda functions).  This is backwards compatible as function pointer is automatically cast'ed to the std::function.