### PR TITLE
Add event handlers and pin/state getters

### DIFF
--- a/src/OneButton.cpp
+++ b/src/OneButton.cpp
@@ -168,6 +168,13 @@ void OneButton::reset(void){
   _isLongPressed = false;
 }
 
+// getter for state and pin
+int OneButton::getState(){ return _state; }
+int OneButton::getPin(){ return _pin; }
+
+// enable and disable double click handler 
+void OneButton::enableDoubleClickEvent(){ _doubleClickEnabled = true; }
+void OneButton::disableDoubleClickEvent(){ _doubleClickEnabled = false; }
 
 /**
  * @brief Check input of the configured pin and then advance the finite state
@@ -211,12 +218,18 @@ void OneButton::tick(bool activeLevel)
     } else if ((activeLevel) &&
                ((unsigned long)(now - _startTime) > _pressTicks)) {
       _isLongPressed = true; // Keep track of long press state
+
+      pressEvent();
       if (_pressFunc)
         _pressFunc();
+
+      longPressStartEvent();
       if (_longPressStartFunc)
         _longPressStartFunc();
       if (_paramLongPressStartFunc)
         _paramLongPressStartFunc(_longPressStartFuncParam);
+
+      duringLongPressEvent();
       if (_duringLongPressFunc)
         _duringLongPressFunc();
       if (_paramDuringLongPressFunc)
@@ -229,9 +242,10 @@ void OneButton::tick(bool activeLevel)
 
   } else if (_state == 2) {
     // waiting for menu pin being pressed the second time or timeout.
-    if ((_doubleClickFunc == NULL && _paramDoubleClickFunc == NULL) ||
+    if ((_doubleClickFunc == NULL && _paramDoubleClickFunc == NULL && _doubleClickEnabled == false ) ||
         (unsigned long)(now - _startTime) > _clickTicks) {
       // this was only a single short click
+      clickEvent();
       if (_clickFunc)
         _clickFunc();
       if (_paramClickFunc)
@@ -250,6 +264,7 @@ void OneButton::tick(bool activeLevel)
     if ((!activeLevel) &&
         ((unsigned long)(now - _startTime) > _debounceTicks)) {
       // this was a 2 click sequence.
+      doubleClickEvent();
       if (_doubleClickFunc)
         _doubleClickFunc();
       if (_paramDoubleClickFunc)
@@ -262,6 +277,7 @@ void OneButton::tick(bool activeLevel)
     // waiting for menu pin being release after long press.
     if (!activeLevel) {
       _isLongPressed = false; // Keep track of long press state
+      longPressStopEvent();
       if (_longPressStopFunc)
         _longPressStopFunc();
       if (_paramLongPressStopFunc)
@@ -271,6 +287,7 @@ void OneButton::tick(bool activeLevel)
     } else {
       // button is being long pressed
       _isLongPressed = true; // Keep track of long press state
+      duringLongPressEvent();
       if (_duringLongPressFunc)
         _duringLongPressFunc();
       if (_paramDuringLongPressFunc)

--- a/src/OneButton.h
+++ b/src/OneButton.h
@@ -68,6 +68,24 @@ public:
   void attachDuringLongPress(callbackFunction newFunction);
   void attachDuringLongPress(parameterizedCallbackFunction newFunction, void* parameter);
 
+  // get FSM state
+  int getState();
+
+  // get PIN
+  virtual int getPin();
+
+  // events based handlers to be overritten as needed in child classes
+  virtual void pressEvent(){return;};
+  virtual void longPressStartEvent(){return;};
+  virtual void longPressStopEvent(){return;};
+  virtual void duringLongPressEvent(){return;};
+  virtual void clickEvent(){return;};
+  virtual void doubleClickEvent(){return;};
+
+  // enabling and disablign doubleClick
+  void enableDoubleClickEvent();
+  void disableDoubleClickEvent();
+
   // ----- State machine functions -----
 
   /**
@@ -98,6 +116,8 @@ private:
   int _buttonPressed;
 
   bool _isLongPressed = false;
+
+  bool _doubleClickEnabled = false;
 
   // These variables will hold functions acting as event source.
   callbackFunction _clickFunc = NULL;


### PR DESCRIPTION
This is the implementation idea annouced in issue #65

A child class will look as this :
```

class Switch : public OneButton {
public:
        int some_attribute;

	// core methods
	// =================
	// constructor and destructor
	Switch(int pin, int activeLow = true, bool pullupActive = true);
	Switch();

        // events
	// -- overrided from OneButton class -----------
	void clickEvent() override;
	void pressEvent() override;
	void longPressStartEvent() override;
	void longPressStopEvent()  override;
	void duringLongPressEvent() override;
	void doubleClickEvent() override;
};


Switch::Switch(int pin, int activeLow, bool pullupActive) 
                                   : OneButton(pin, activeLow, pullupActive){
  // other initializations if needed
}

// events
void Switch::clickEvent()  {
    // do something linked to the Switch click event
   // like using the some_attribute
 
}
void Switch::pressEvent()  {
     /// implement the press event handler
}
 // etc...


```
This will be very helpfull if someone have a bunch of buttons and that the action is handled the same way. Ex. linking buttons to toggle state of specefic output pin. We need just to define the output pin as an attribute, keep track of the state of the output pin value  and in the clickEvent handler  do a digitalWrite with the toggled value...