### PR TITLE
allow visibility on current button handling state (for power management)

### DIFF
--- a/src/OneButton.h
+++ b/src/OneButton.h
@@ -143,6 +143,13 @@ public:
    */
   void reset(void);
 
+  /**
+   * @return true if we are currently handling button press flow
+   * 
+   * (This allows power sensitive applications to know when it is safe to power down the main CPU)
+   */
+  bool isIdle() const { return _state == 0; }
+
 private:
   int _pin; // hardware pin number.
   unsigned int _debounceTicks = 50; // number of ticks for debounce times.


### PR DESCRIPTION
For my application (and some others?) I need to keep the CPU sleeping almost all of the time.  Therefore polling on the current msec won't work while in that mode.  This minor commit adds a bool so I can see if the button state machine is actively looking at a press sequence (in that case I don't suppress sleep).

If others want this you are welcome to it.  Thanks for the nice lib. -kevin