### PR TITLE
docs: add docs for lambda-with-context use-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ void loop() {
 ```
 
 
+### Usage with lambdas that capture context
+
+You **can't pass** a lambda-**with-context** to an argument which expects a **function pointer**. To work that around, 
+use `paramtererizedCallbackFunction`. We pass the context (so the pointer to the object we want to access) to the library
+and it will give it back to the lambda.
+
+```CPP
+okBtn.attachClick([](void *ctx){Serial.println(*(((BtnHandler*)(ctx))) -> state}}), this);
+```
+
+
 ## State Events
 
 Here's a full list of events handled by this library:
@@ -142,17 +153,6 @@ it is hard to click twice or you will create a press instead of a click.
 | ----------------------- | ------------------------------------------------------------------------------ |
 | `bool isLongPressed()`  | Detect whether or not the button is currently inside a long press.             |
 | `int getPressedTicks()` | Get the current number of milliseconds that the button has been held down for. |
-
-
-### Usage with lambdas that capture context
-
-You **can't pass** a lambda-**with-context** to an argument which expects a **function pointer**. To work that around, 
-use `paramtererizedCallbackFunction`. We pass the context (so the pointer to the object we want to access) to the library
-and it will give it back to the lambda.
-
-```CPP
-okBtn.attachClick([](void *ctx){Serial.println(*(((BtnHandler*)(ctx))) -> state}}), this);
-```
 
 
 ### `tick()` and `reset()`

--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ it is hard to click twice or you will create a press instead of a click.
 | `int getPressedTicks()` | Get the current number of milliseconds that the button has been held down for. |
 
 
+### Usage with lambdas that capture context
+
+You **can't pass** a lambda-**with-context** to an argument which expects a **function pointer**. To work that around, 
+use `paramtererizedCallbackFunction`. We pass the context (so the pointer to the object we want to access) to the library
+and it will give it back to the lambda.
+
+```CPP
+okBtn.attachClick([](void *ctx){Serial.println(*(((BtnHandler*)(ctx))) -> state}}), this);
+```
+
+
 ### `tick()` and `reset()`
 
 You can specify a logic level when calling `tick(bool)`, which will skip reading the pin and use


### PR DESCRIPTION
Adequately explained in #112. I don't think this warrants an update to the library, rather: to the documentation.