### PR TITLE
Fix #91 and #88

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ There is no functional change on them.
 | Function                | Description                                                                    |
 | ----------------------- | ------------------------------------------------------------------------------ |
 | `bool isLongPressed()`  | Detect whether or not the button is currently inside a long press.             |
-| `int getPressedTicks()` | Get the current number of milliseconds that the button has been held down for. |
+| `int getPressedMs()`    | Get the current number of milliseconds that the button has been held down for. |
 | `int pin()`             | Get the OneButton pin                                                          |
 | `int state()`           | Get the OneButton state                                                        |
 | `int debouncedValue()`  | Get the OneButton debounced value                                              |

--- a/examples/LongPressEvents/LongPressEvents.ino
+++ b/examples/LongPressEvents/LongPressEvents.ino
@@ -36,7 +36,7 @@ void setup()
   button.attachDuringLongPress(DuringLongPress, &button);
   button.attachLongPressStop(LongPressStop, &button);
 
-  button.setLongPressIntervalMs(400);
+  button.setLongPressIntervalMs(1000);
 } // setup
 
 

--- a/examples/LongPressEvents/LongPressEvents.ino
+++ b/examples/LongPressEvents/LongPressEvents.ino
@@ -35,6 +35,8 @@ void setup()
   button.attachLongPressStart(LongPressStart, &button);
   button.attachDuringLongPress(DuringLongPress, &button);
   button.attachLongPressStop(LongPressStop, &button);
+
+  button.setLongPressIntervalMs(400);
 } // setup
 
 
@@ -63,17 +65,11 @@ void LongPressStop(void *oneButton)
   Serial.println("\t - LongPressStop()\n");
 }
 
-unsigned long previous = 0;
-
 // this function will be called when the button is held down.
 void DuringLongPress(void *oneButton)
 {
-  unsigned long now = millis();
-  if ((now - previous) >= 1000) {
-    previous = now;
-    Serial.print(((OneButton *)oneButton)->getPressedMs());
-    Serial.println("\t - DuringLongPress()");
-  }
+  Serial.print(((OneButton *)oneButton)->getPressedMs());
+  Serial.println("\t - DuringLongPress()");
 }
 
 // End

--- a/examples/LongPressEvents/LongPressEvents.ino
+++ b/examples/LongPressEvents/LongPressEvents.ino
@@ -1,3 +1,30 @@
+/*
+ This is a sample sketch to show how to use the OneButtonLibrary
+ to detect long press events on a button.
+ The library internals are explained at
+ http://www.mathertel.de/Arduino/OneButtonLibrary.aspx
+
+ Setup a test circuit:
+ * Connect a pushbutton to PIN_INPUT (ButtonPin) and ground.
+
+ The sketch shows how to setup the library and bind the functions (LongPressStart, LongPressStop, DuringLongPress) to the events.
+ In the loop function the button.tick function must be called as often as you like.
+ The output of the program is:
+
+OneButton Example.
+Please press and hold the button for a few seconds.
+810	     - LongPressStart()
+820	     - DuringLongPress()
+1820	 - DuringLongPress()
+2820	 - DuringLongPress()
+3820	 - DuringLongPress()
+4820	 - DuringLongPress()
+5820	 - DuringLongPress()
+6550	 - LongPressStop()
+*/
+
+// 05.05.2023 created by Ihor Nehrutsa
+
 #include "OneButton.h"
 
 #if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO_EVERY)

--- a/examples/LongPressEvents/LongPressEvents.ino
+++ b/examples/LongPressEvents/LongPressEvents.ino
@@ -1,0 +1,79 @@
+#include "OneButton.h"
+
+#if defined(ARDUINO_AVR_UNO) || defined(ARDUINO_AVR_NANO_EVERY)
+// Example for Arduino UNO with input button on pin 2
+#define PIN_INPUT 2
+
+#elif defined(ESP8266)
+// Example for NodeMCU with input button using FLASH button on D3
+#define PIN_INPUT D3
+
+#elif defined(ESP32)
+// Example pin assignments for a ESP32 board
+// Some boards have a BOOT switch using GPIO 0.
+#define PIN_INPUT 0
+
+#endif
+
+// Setup a new OneButton on pin PIN_INPUT
+// The 2. parameter activeLOW is true, because external wiring sets the button to LOW when pressed.
+OneButton button(PIN_INPUT, true);
+
+// In case the momentary button puts the input to HIGH when pressed:
+// The 2. parameter activeLOW is false when the external wiring sets the button to HIGH when pressed.
+// The 3. parameter can be used to disable the PullUp .
+// OneButton button(PIN_INPUT, false, false);
+
+// setup code here, to run once:
+void setup()
+{
+  Serial.begin(115200);
+  Serial.println("\nOneButton Example.");
+  Serial.println("Please press and hold the button for a few seconds.");
+
+  // link functions to be called on events.
+  button.attachLongPressStart(LongPressStart, &button);
+  button.attachDuringLongPress(DuringLongPress, &button);
+  button.attachLongPressStop(LongPressStop, &button);
+} // setup
+
+
+// main code here, to run repeatedly:
+void loop()
+{
+  // keep watching the push button:
+  button.tick();
+
+  // You can implement other code in here or just wait a while
+  delay(10);
+} // loop
+
+
+// this function will be called when the button started long pressed.
+void LongPressStart(void *oneButton)
+{
+  Serial.print(((OneButton *)oneButton)->getPressedMs());
+  Serial.println("\t - LongPressStart()");
+}
+
+// this function will be called when the button is released.
+void LongPressStop(void *oneButton)
+{
+  Serial.print(((OneButton *)oneButton)->getPressedMs());
+  Serial.println("\t - LongPressStop()\n");
+}
+
+unsigned long previous = 0;
+
+// this function will be called when the button is held down.
+void DuringLongPress(void *oneButton)
+{
+  unsigned long now = millis();
+  if ((now - previous) >= 1000) {
+    previous = now;
+    Serial.print(((OneButton *)oneButton)->getPressedMs());
+    Serial.println("\t - DuringLongPress()");
+  }
+}
+
+// End

--- a/src/OneButton.cpp
+++ b/src/OneButton.cpp
@@ -308,7 +308,6 @@ void OneButton::_fsm(bool activeLevel)
 
     if (!activeLevel) {
       _newState(OneButton::OCS_PRESSEND);
-      _startTime = now;
 
     } else {
       // still the button is pressed

--- a/src/OneButton.cpp
+++ b/src/OneButton.cpp
@@ -311,7 +311,7 @@ void OneButton::_fsm(bool activeLevel)
 
     } else {
       // still the button is pressed
-      if ((now - _lastDuringLongPressTime) >= _long_press_intrval_ms) {
+      if ((now - _lastDuringLongPressTime) >= _long_press_interval_ms) {
         if (_duringLongPressFunc) _duringLongPressFunc();
         if (_paramDuringLongPressFunc) _paramDuringLongPressFunc(_duringLongPressFuncParam);
         _lastDuringLongPressTime = now;

--- a/src/OneButton.cpp
+++ b/src/OneButton.cpp
@@ -311,8 +311,11 @@ void OneButton::_fsm(bool activeLevel)
 
     } else {
       // still the button is pressed
-      if (_duringLongPressFunc) _duringLongPressFunc();
-      if (_paramDuringLongPressFunc) _paramDuringLongPressFunc(_duringLongPressFuncParam);
+      if ((now - _lastDuringLongPressTime) >= _long_press_intrval_ms) {
+        if (_duringLongPressFunc) _duringLongPressFunc();
+        if (_paramDuringLongPressFunc) _paramDuringLongPressFunc(_duringLongPressFuncParam);
+        _lastDuringLongPressTime = now;
+      }
     } // if
     break;
 

--- a/src/OneButton.h
+++ b/src/OneButton.h
@@ -72,6 +72,12 @@ public:
   void setPressTicks(const unsigned int ms) { setPressMs(ms); }; // deprecated
   void setPressMs(const unsigned int ms);
 
+  /**
+   * set interval in msecs between calls of the DuringLongPress event.
+   * 0 ms is the fastest events calls.
+   */
+  void setLongPressIntervalMs(const unsigned int ms) { _long_press_intrval_ms = ms; };
+
   // ----- Attach events functions -----
 
   /**
@@ -111,6 +117,7 @@ public:
 
   /**
    * Attach an event to fire periodically while the button is held down.
+   * The period of calls is set by setLongPressIntervalMs(ms).
    * @param newFunction
    */
   void attachDuringLongPress(callbackFunction newFunction);
@@ -226,6 +233,9 @@ private:
   unsigned long _startTime = 0; // start time of current activeLevel change
   int _nClicks = 0;             // count the number of clicks with this variable
   int _maxClicks = 1;           // max number (1, 2, multi=3) of clicks of interest by registration of event functions.
+
+  unsigned int _long_press_intrval_ms = 0; // interval in msecs between calls of the DuringLongPress event
+  unsigned long _lastDuringLongPressTime = 0; // used to produce the DuringLongPress interval
 
 public:
   int pin() const { return _pin; };

--- a/src/OneButton.h
+++ b/src/OneButton.h
@@ -76,7 +76,7 @@ public:
    * set interval in msecs between calls of the DuringLongPress event.
    * 0 ms is the fastest events calls.
    */
-  void setLongPressIntervalMs(const unsigned int ms) { _long_press_intrval_ms = ms; };
+  void setLongPressIntervalMs(const unsigned int ms) { _long_press_interval_ms = ms; };
 
   // ----- Attach events functions -----
 
@@ -234,7 +234,7 @@ private:
   int _nClicks = 0;             // count the number of clicks with this variable
   int _maxClicks = 1;           // max number (1, 2, multi=3) of clicks of interest by registration of event functions.
 
-  unsigned int _long_press_intrval_ms = 0; // interval in msecs between calls of the DuringLongPress event
+  unsigned int _long_press_interval_ms = 0; // interval in msecs between calls of the DuringLongPress event
   unsigned long _lastDuringLongPressTime = 0; // used to produce the DuringLongPress interval
 
 public:

--- a/src/OneButton.h
+++ b/src/OneButton.h
@@ -223,7 +223,7 @@ private:
   unsigned long _lastDebounceTime = 0; // millis()
   unsigned long now = 0;               // millis()
 
-  unsigned long _startTime = 0; // start of current input change to checking debouncing
+  unsigned long _startTime = 0; // start time of current activeLevel change
   int _nClicks = 0;             // count the number of clicks with this variable
   int _maxClicks = 1;           // max number (1, 2, multi=3) of clicks of interest by registration of event functions.
 
@@ -232,6 +232,12 @@ public:
   stateMachine_t state() const { return _state; };
   int debounce(const int value);
   int debouncedValue() const { return debouncedPinLevel; };
+
+  /**
+   * @brief Use this function in the DuringLongPress and LongPressStop events to get the time since the button was pressed.
+   * @return milliseconds from the start of the button press.
+   */
+  unsigned long getPressedMs() { return(millis() - _startTime); };
 };
 
 #endif


### PR DESCRIPTION
Add getPressedMs() function.

Add LongPressEvents.ino example.
```
OneButton Example.
Please press and hold the button for a few seconds.
810	 - LongPressStart()
820	 - DuringLongPress()
1820	 - DuringLongPress()
2820	 - DuringLongPress()
3820	 - DuringLongPress()
4820	 - DuringLongPress()
5820	 - DuringLongPress()
6550	 - LongPressStop()
```
In the first column, milliseconds from the start of pressing the button.
