### PR TITLE
Addedd #define for button configuration

### DIFF
--- a/src/OneButton.h
+++ b/src/OneButton.h
@@ -27,6 +27,12 @@
 
 #include "Arduino.h"
 
+#define BUTTON_ACTIVE_LOW true
+#define BUTTON_ACTIVE_HIGH false
+#define BUTTON_PULLUP true
+#define BUTTON_NO_PULLUP false
+
+
 // ----- Callback function types -----
 
 extern "C" {


### PR DESCRIPTION
Added the #define to make clearest and easier the initial configuration.

```
#define BUTTON_ACTIVE_LOW true
#define BUTTON_ACTIVE_HIGH false
#define BUTTON_PULLUP true
#define BUTTON_NO_PULLUP false
```

use:
`OneButton button(5, BUTTON_ACTIVE_LOW, BUTTON_PULLUP);`
instead of:
`OneButton button(5, true, true);`

