### PR TITLE
Properly handle _debounce_ms of 0

### DIFF
--- a/src/OneButton.cpp
+++ b/src/OneButton.cpp
@@ -194,7 +194,8 @@ bool OneButton::debounce(const bool value) {
   now = millis();  // current (relative) time in msecs.
 
   // Don't debounce going into active state, if _debounce_ms is negative
-  if (value && _debounce_ms < 0)
+  // Don't debounce at all if _debounce_ms is 0
+  if (_debounce_ms == 0 || (value && _debounce_ms < 0))
     debouncedLevel = value;
 
   if (_lastDebounceLevel == value) {


### PR DESCRIPTION
While troubleshooting OneButton on a device with an eink display, I realized that setting _debounce_ms to 0 didn't actually disable debounce as expected. This is the simplest solution, though if you want to maintain the current behavior, could also add a bool to disable debounce.